### PR TITLE
Add LDFLAGS to nss-altfiles-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $O: src/nss_altfiles/files-XXX.c src/nss_altfiles/files-parse.c src/compat.h
 src/nss_altfiles/files-hosts.o: src/resolv/mapv4v6addr.h  src/resolv/res_hconf.h
 
 nss-altfiles-config: src/main.o
-	$(CC) -o $@ $^
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
 	find src -name '*.o' -delete


### PR DESCRIPTION
In order to build a 32-bit library on 64-bit RHEL7 I added -m32 to CFLAGS, but the entry in the Makefile for `nss-altfiles-confg` did not include LDFLAGS (which include CFLAGS). So I've added that in the above change and now I can build a 32-bit version on 64-bit RHEL7.